### PR TITLE
Eslint reads webpack configuration from webpack's file

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -44,7 +44,11 @@
     }]
   },
   "settings": {
-    "import/resolver": "webpack",
+    "import/resolver": {
+      "webpack": {
+        "config": "webpack.config.js"
+      },
+    },
     "flowtype": {
         "onlyFilesWithFlowAnnotation": true,
     },


### PR DESCRIPTION
# Why are you doing this?
To correctly validate `.jsx` files